### PR TITLE
ci(maestro): cancel stale PR runs

### DIFF
--- a/.github/workflows/maestro_ios.yaml
+++ b/.github/workflows/maestro_ios.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 concurrency:
-  group: maestro-${{ github.ref }}
+  group: maestro-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- scope Maestro iOS workflow concurrency by workflow and PR number when available
- keep push-to-main runs grouped by ref
- ensure older queued PR runs are canceled so only the latest run executes

Closes #61

## Testing
- not run (GitHub Actions workflow change only)