### PR TITLE
test: extend iOS Maestro flow with bench press

### DIFF
--- a/maestro-test/ios-flow.yaml
+++ b/maestro-test/ios-flow.yaml
@@ -46,8 +46,23 @@ appId: com.fitnesspipe.fitnessPipe
     timeout: 60000
 - assertVisible: "reps"
 
-# Switch back to Lateral Raise
+# Exercise Navigation — switch to Bench Press
 - tapOn: "Single Squat"
+- extendedWaitUntil:
+    visible: "Bench Press"
+    timeout: 5000
+- tapOn: "Bench Press"
+- extendedWaitUntil:
+    visible: "Bench Press"
+    timeout: 11000
+# Wait for counter to increment > 0 (virtual pose needs time for detection + counting)
+- extendedWaitUntil:
+    visible: "[1-9][0-9]*"
+    timeout: 60000
+- assertVisible: "reps"
+
+# Switch back to Lateral Raise
+- tapOn: "Bench Press"
 - extendedWaitUntil:
     visible: "Lateral Raise"
     timeout: 5000


### PR DESCRIPTION
## Summary
- add Bench Press as the third exercise in the iOS Maestro flow
- keep the existing simple dropdown/wait/assert pattern used for the other exercises
- preserve the final return to Lateral Raise and landscape smoke check

## Test Plan
- [x] flutter analyze
- [x] flutter test
- [x] (cd packages/fitness_counter && flutter test)
- [x] dart format lib/ test/ packages/ --set-exit-if-changed

Closes #81