### PR TITLE
feat(ui): optimize camera screen layout and fix UX issues (#86)

### DIFF
--- a/lib/presentation/screens/pose_detection_controller.dart
+++ b/lib/presentation/screens/pose_detection_controller.dart
@@ -28,12 +28,13 @@ class _PoseDetectionScreenState extends State<PoseDetectionScreen>
   FeedbackCooldownManager? _feedbackCooldownManager;
   Timer? _feedbackClearTimer;
 
-  // Exercise demo tracking
+  // Exercise demo / settings tracking
   final ExerciseDemoService _exerciseDemoService = ExerciseDemoService();
   bool _isDemoShowing = false;
+  bool _isSettingsShowing = false;
 
   // Threshold configuration
-  double _topThreshold = 70.0;
+  double _topThreshold = 60.0;
   double _bottomThreshold = 25.0;
   double _squatTopThreshold = 170.0;
   double _squatBottomThreshold = 160.0;

--- a/lib/presentation/screens/pose_detection_controller.dart
+++ b/lib/presentation/screens/pose_detection_controller.dart
@@ -35,7 +35,7 @@ class _PoseDetectionScreenState extends State<PoseDetectionScreen>
 
   // Threshold configuration
   double _topThreshold = 60.0;
-  double _bottomThreshold = 25.0;
+  double _bottomThreshold = 30.0;
   double _squatTopThreshold = 170.0;
   double _squatBottomThreshold = 160.0;
   SingleSquatSensitivity _singleSquatSensitivity =

--- a/lib/presentation/screens/pose_detection_exercise.dart
+++ b/lib/presentation/screens/pose_detection_exercise.dart
@@ -3,10 +3,11 @@ part of 'pose_detection_screen.dart';
 extension _PoseDetectionScreenExercise on _PoseDetectionScreenState {
   void _processPoseWithCounter(Pose pose) {
     if (_selectedExercise == null) return;
-    if (_isDemoShowing) return;
+    if (_isDemoShowing || _isSettingsShowing) return;
 
     final poseFrame = _poseAdapter.convert(pose);
     RepEvent? event;
+    bool isWaiting = false;
 
     _updateState(() {
       if (_selectedExercise == ExerciseType.lateralRaise &&
@@ -15,30 +16,7 @@ extension _PoseDetectionScreenExercise on _PoseDetectionScreenState {
         final state = _lateralRaiseCounter!.state;
         _repCount = state.repCount;
         _currentAngle = state.smoothedAngle;
-
-        if (_lateralRaiseFormAnalyzer != null) {
-          _currentFeedback = _lateralRaiseFormAnalyzer!.analyzeFrame(
-            poseFrame.landmarks,
-          );
-
-          if (_currentFeedback != null && _feedbackCooldownManager != null) {
-            final filtered = _feedbackCooldownManager!.processFeedback(
-              _currentFeedback!,
-            );
-            if (filtered != null) {
-              _displayedFeedback = filtered;
-              _voiceGuidanceService.speak(filtered);
-              _feedbackClearTimer?.cancel();
-              _feedbackClearTimer = Timer(const Duration(seconds: 3), () {
-                if (mounted) {
-                  _updateState(() {
-                    _displayedFeedback = null;
-                  });
-                }
-              });
-            }
-          }
-        }
+        isWaiting = state.phase == LateralRaisePhase.waiting;
 
         final (label, color) = switch (state.phase) {
           LateralRaisePhase.waiting => ('Ready...', Colors.grey),
@@ -49,36 +27,19 @@ extension _PoseDetectionScreenExercise on _PoseDetectionScreenState {
         };
         _phaseLabel = label;
         _phaseColor = color;
+
+        if (!isWaiting) {
+          _processFormFeedback(
+            _lateralRaiseFormAnalyzer?.analyzeFrame(poseFrame.landmarks),
+          );
+        }
       } else if (_selectedExercise == ExerciseType.singleSquat &&
           _singleSquatCounter != null) {
         event = _singleSquatCounter!.processPose(poseFrame);
         final state = _singleSquatCounter!.state;
         _repCount = state.repCount;
         _currentAngle = state.smoothedAngle;
-
-        if (_singleSquatFormAnalyzer != null) {
-          _currentFeedback = _singleSquatFormAnalyzer!.analyzeFrame(
-            poseFrame.landmarks,
-          );
-
-          if (_currentFeedback != null && _feedbackCooldownManager != null) {
-            final filtered = _feedbackCooldownManager!.processFeedback(
-              _currentFeedback!,
-            );
-            if (filtered != null) {
-              _displayedFeedback = filtered;
-              _voiceGuidanceService.speak(filtered);
-              _feedbackClearTimer?.cancel();
-              _feedbackClearTimer = Timer(const Duration(seconds: 3), () {
-                if (mounted) {
-                  _updateState(() {
-                    _displayedFeedback = null;
-                  });
-                }
-              });
-            }
-          }
-        }
+        isWaiting = state.phase == SingleSquatPhase.waiting;
 
         final (label, color) = switch (state.phase) {
           SingleSquatPhase.waiting => ('Ready...', Colors.grey),
@@ -89,36 +50,19 @@ extension _PoseDetectionScreenExercise on _PoseDetectionScreenState {
         };
         _phaseLabel = label;
         _phaseColor = color;
+
+        if (!isWaiting) {
+          _processFormFeedback(
+            _singleSquatFormAnalyzer?.analyzeFrame(poseFrame.landmarks),
+          );
+        }
       } else if (_selectedExercise == ExerciseType.benchPress &&
           _benchPressCounter != null) {
         event = _benchPressCounter!.processPose(poseFrame);
         final state = _benchPressCounter!.state;
         _repCount = state.repCount;
         _currentAngle = state.smoothedAngle;
-
-        if (_benchPressFormAnalyzer != null) {
-          _currentFeedback = _benchPressFormAnalyzer!.analyzeFrame(
-            poseFrame.landmarks,
-          );
-
-          if (_currentFeedback != null && _feedbackCooldownManager != null) {
-            final filtered = _feedbackCooldownManager!.processFeedback(
-              _currentFeedback!,
-            );
-            if (filtered != null) {
-              _displayedFeedback = filtered;
-              _voiceGuidanceService.speak(filtered);
-              _feedbackClearTimer?.cancel();
-              _feedbackClearTimer = Timer(const Duration(seconds: 3), () {
-                if (mounted) {
-                  _updateState(() {
-                    _displayedFeedback = null;
-                  });
-                }
-              });
-            }
-          }
-        }
+        isWaiting = state.phase == BenchPressPhase.waiting;
 
         final (label, color) = switch (state.phase) {
           BenchPressPhase.waiting => ('Ready...', Colors.grey),
@@ -129,6 +73,12 @@ extension _PoseDetectionScreenExercise on _PoseDetectionScreenState {
         };
         _phaseLabel = label;
         _phaseColor = color;
+
+        if (!isWaiting) {
+          _processFormFeedback(
+            _benchPressFormAnalyzer?.analyzeFrame(poseFrame.landmarks),
+          );
+        }
       }
     });
 
@@ -136,10 +86,34 @@ extension _PoseDetectionScreenExercise on _PoseDetectionScreenState {
       HapticFeedback.mediumImpact();
     }
 
-    if (_phaseColor == Colors.grey && _selectedExercise != null) {
+    if (isWaiting && _selectedExercise != null) {
       _voiceGuidanceService.speakStartPrompt(
         _selectedExercise!.config.startPositionPrompt,
       );
+    }
+  }
+
+  /// Shared form feedback processing: filters through cooldown, updates
+  /// displayed feedback, triggers voice guidance, and schedules auto-clear.
+  /// Called only when the exercise is actively counting (not in waiting phase).
+  void _processFormFeedback(FormFeedback? feedback) {
+    _currentFeedback = feedback;
+    if (_currentFeedback == null || _feedbackCooldownManager == null) return;
+
+    final filtered = _feedbackCooldownManager!.processFeedback(
+      _currentFeedback!,
+    );
+    if (filtered != null) {
+      _displayedFeedback = filtered;
+      _voiceGuidanceService.speak(filtered);
+      _feedbackClearTimer?.cancel();
+      _feedbackClearTimer = Timer(const Duration(seconds: 3), () {
+        if (mounted) {
+          _updateState(() {
+            _displayedFeedback = null;
+          });
+        }
+      });
     }
   }
 
@@ -242,6 +216,13 @@ extension _PoseDetectionScreenExercise on _PoseDetectionScreenState {
   Future<void> _showThresholdSettings() async {
     if (_selectedExercise == null) return;
 
+    _updateState(() {
+      _isSettingsShowing = true;
+      _displayedFeedback = null;
+      _feedbackClearTimer?.cancel();
+    });
+    _voiceGuidanceService.stop();
+
     double currentTop;
     double currentBottom;
     if (_selectedExercise == ExerciseType.lateralRaise) {
@@ -256,24 +237,31 @@ extension _PoseDetectionScreenExercise on _PoseDetectionScreenState {
     }
 
     final exerciseType = _selectedExercise!;
-    final result = await showThresholdSettingsSheet(
-      context: context,
-      initialTopThreshold: currentTop,
-      initialBottomThreshold: currentBottom,
-      exerciseType: exerciseType,
-      initialSensitivity: exerciseType == ExerciseType.lateralRaise
-          ? _currentSensitivity
-          : exerciseType == ExerciseType.singleSquat
-          ? _singleSquatSensitivity
-          : exerciseType == ExerciseType.benchPress
-          ? _benchPressSensitivity
-          : null,
-      onShowDemo: () => _showExerciseDemo(exerciseType),
-    );
+    ThresholdDialogResult? result;
+    try {
+      result = await showThresholdSettingsSheet(
+        context: context,
+        initialTopThreshold: currentTop,
+        initialBottomThreshold: currentBottom,
+        exerciseType: exerciseType,
+        initialSensitivity: exerciseType == ExerciseType.lateralRaise
+            ? _currentSensitivity
+            : exerciseType == ExerciseType.singleSquat
+            ? _singleSquatSensitivity
+            : exerciseType == ExerciseType.benchPress
+            ? _benchPressSensitivity
+            : null,
+        onShowDemo: () => _showExerciseDemo(exerciseType),
+      );
+    } finally {
+      if (mounted) {
+        _updateState(() => _isSettingsShowing = false);
+      }
+    }
 
     if (result != null) {
       _updateState(() {
-        final newTop = result.topThreshold;
+        final newTop = result!.topThreshold;
         final newBottom = result.bottomThreshold;
 
         if (_selectedExercise == ExerciseType.lateralRaise) {

--- a/lib/presentation/screens/pose_detection_view.dart
+++ b/lib/presentation/screens/pose_detection_view.dart
@@ -2,91 +2,90 @@ part of 'pose_detection_screen.dart';
 
 extension _PoseDetectionScreenView on _PoseDetectionScreenState {
   Widget _buildScaffold() {
-    return Scaffold(
-      backgroundColor: Colors.black,
-      appBar: AppBar(
-        title: const Text('FitnessPipe'),
-        actions: [
-          if (_canShowInputSelector)
-            PopupMenuButton<PoseDetectionInputMode>(
-              initialValue: _currentInputMode,
-              icon: const Icon(Icons.cameraswitch),
-              tooltip: 'Switch Input',
-              onSelected: _handleInputModeSelection,
-              itemBuilder: (context) => _availableInputModes
-                  .map(
-                    (mode) => PopupMenuItem<PoseDetectionInputMode>(
-                      value: mode,
-                      child: Row(
-                        children: [
-                          Icon(
-                            _currentInputMode == mode
-                                ? Icons.radio_button_checked
-                                : Icons.radio_button_off,
-                            size: 18,
-                          ),
-                          const SizedBox(width: 8),
-                          Text(mode.label),
-                        ],
-                      ),
-                    ),
-                  )
-                  .toList(),
-            ),
-          IconButton(
-            icon: Icon(
-              _currentPose != null ? Icons.visibility : Icons.visibility_off,
-            ),
-            onPressed: () {},
-            tooltip: _currentPose != null ? 'Pose Detected' : 'No Pose',
-          ),
-        ],
-      ),
-      body: _buildBody(),
-    );
+    return Scaffold(backgroundColor: Colors.black, body: _buildBody());
   }
 
   Widget _buildBody() {
     if (_isLoading) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CircularProgressIndicator(
-              color: Theme.of(context).colorScheme.primary,
+      return Stack(
+        children: [
+          Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                CircularProgressIndicator(
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Initializing camera...',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            Text(
-              'Initializing camera...',
-              style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          Positioned(
+            top: MediaQuery.of(context).padding.top + 8,
+            left: 0,
+            right: 0,
+            child: const Center(
+              child: Text(
+                'FitnessPipe',
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: -0.4,
+                ),
+              ),
             ),
-          ],
-        ),
+          ),
+        ],
       );
     }
 
     if (_errorMessage != null) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.error_outline, color: Colors.red, size: 64),
-              const SizedBox(height: 16),
-              Text(
-                _errorMessage!,
-                style: Theme.of(context).textTheme.bodyLarge,
-                textAlign: TextAlign.center,
+      return Stack(
+        children: [
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error_outline, color: Colors.red, size: 64),
+                  const SizedBox(height: 16),
+                  Text(
+                    _errorMessage!,
+                    style: Theme.of(context).textTheme.bodyLarge,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton(
+                    onPressed: _initializeCamera,
+                    child: const Text('Retry'),
+                  ),
+                ],
               ),
-              const SizedBox(height: 24),
-              ElevatedButton(
-                onPressed: _initializeCamera,
-                child: const Text('Retry'),
-              ),
-            ],
+            ),
           ),
-        ),
+          Positioned(
+            top: MediaQuery.of(context).padding.top + 8,
+            left: 0,
+            right: 0,
+            child: const Center(
+              child: Text(
+                'FitnessPipe',
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: -0.4,
+                ),
+              ),
+            ),
+          ),
+        ],
       );
     }
 
@@ -123,6 +122,10 @@ extension _PoseDetectionScreenView on _PoseDetectionScreenState {
       poseLabel: _filePreviewPoseLabel,
       badgeLabel: _filePreviewBadgeLabel,
       badgeColor: _filePreviewBadgeColor,
+      showInputSelector: _canShowInputSelector,
+      currentInputMode: _currentInputMode,
+      availableInputModes: _availableInputModes,
+      onInputModeSelected: _handleInputModeSelection,
     );
   }
 
@@ -137,38 +140,46 @@ extension _PoseDetectionScreenView on _PoseDetectionScreenState {
             ? _cameraImageSize!.width / _cameraImageSize!.height
             : 16 / 9;
 
-        return Center(
-          child: AspectRatio(
-            aspectRatio: aspectRatio,
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                Image.file(
-                  _currentPreviewFrameFile!,
-                  fit: BoxFit.cover,
-                  gaplessPlayback: true,
-                  excludeFromSemantics: true,
-                ),
-                if (_currentPose != null)
-                  AspectRatio(
-                    aspectRatio: aspectRatio,
-                    child: CustomPaint(
-                      painter: SkeletonPainter(
-                        pose: _currentPose,
-                        rotationDegrees: 0,
-                        imageSize: _cameraImageSize,
-                        inputsAreRotated: false,
-                        skeletonColor: Colors.greenAccent,
-                        visibleLandmarks: _visibleLandmarks,
-                        visibleBones: _visibleBones,
-                        guide: _currentGuide,
-                      ),
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            FittedBox(
+              fit: BoxFit.cover,
+              clipBehavior: Clip.hardEdge,
+              child: SizedBox(
+                width: constraints.maxWidth,
+                height: constraints.maxWidth / aspectRatio,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    Image.file(
+                      _currentPreviewFrameFile!,
+                      fit: BoxFit.cover,
+                      gaplessPlayback: true,
+                      excludeFromSemantics: true,
                     ),
-                  ),
-                _buildOverlay(),
-              ],
+                    if (_currentPose != null)
+                      AspectRatio(
+                        aspectRatio: aspectRatio,
+                        child: CustomPaint(
+                          painter: SkeletonPainter(
+                            pose: _currentPose,
+                            rotationDegrees: 0,
+                            imageSize: _cameraImageSize,
+                            inputsAreRotated: false,
+                            skeletonColor: Colors.greenAccent,
+                            visibleLandmarks: _visibleLandmarks,
+                            visibleBones: _visibleBones,
+                            guide: _currentGuide,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
             ),
-          ),
+            _buildOverlay(),
+          ],
         );
       },
     );
@@ -187,22 +198,22 @@ extension _PoseDetectionScreenView on _PoseDetectionScreenState {
     final selectedCamera = _macOSCameras![_selectedMacOSCameraIndex];
 
     return Stack(
+      fit: StackFit.expand,
       children: [
-        Center(
-          child: CameraMacOSView(
-            key: _macOSCameraKey,
-            deviceId: selectedCamera.deviceId,
-            fit: BoxFit.contain,
-            cameraMode: CameraMacOSMode.video,
-            onCameraInizialized: _onMacOSCameraInitialized,
-            onCameraDestroyed: () {
-              _macOSCameraController = null;
-              return const SizedBox.shrink();
-            },
-          ),
+        CameraMacOSView(
+          key: _macOSCameraKey,
+          deviceId: selectedCamera.deviceId,
+          fit: BoxFit.cover,
+          cameraMode: CameraMacOSMode.video,
+          onCameraInizialized: _onMacOSCameraInitialized,
+          onCameraDestroyed: () {
+            _macOSCameraController = null;
+            return const SizedBox.shrink();
+          },
         ),
+        _buildOverlay(),
         Positioned(
-          bottom: 16,
+          bottom: MediaQuery.of(context).padding.bottom + 48,
           left: 16,
           right: 16,
           child: Container(
@@ -277,33 +288,41 @@ extension _PoseDetectionScreenView on _PoseDetectionScreenState {
               ? landscapeAspectRatio
               : portraitAspectRatio;
 
-          return Center(
-            child: AspectRatio(
-              aspectRatio: aspectRatio,
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  mobile_camera.CameraPreview(controller),
-                  if (_currentPose != null)
-                    AspectRatio(
-                      aspectRatio: aspectRatio,
-                      child: CustomPaint(
-                        painter: SkeletonPainter(
-                          pose: _currentPose,
-                          rotationDegrees: _sensorOrientation,
-                          imageSize: null,
-                          inputsAreRotated: false,
-                          skeletonColor: Colors.greenAccent,
-                          visibleLandmarks: _visibleLandmarks,
-                          visibleBones: _visibleBones,
-                          guide: _currentGuide,
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              FittedBox(
+                fit: BoxFit.cover,
+                clipBehavior: Clip.hardEdge,
+                child: SizedBox(
+                  width: constraints.maxWidth,
+                  height: constraints.maxWidth / aspectRatio,
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      mobile_camera.CameraPreview(controller),
+                      if (_currentPose != null)
+                        AspectRatio(
+                          aspectRatio: aspectRatio,
+                          child: CustomPaint(
+                            painter: SkeletonPainter(
+                              pose: _currentPose,
+                              rotationDegrees: _sensorOrientation,
+                              imageSize: null,
+                              inputsAreRotated: false,
+                              skeletonColor: Colors.greenAccent,
+                              visibleLandmarks: _visibleLandmarks,
+                              visibleBones: _visibleBones,
+                              guide: _currentGuide,
+                            ),
+                          ),
                         ),
-                      ),
-                    ),
-                  _buildOverlay(),
-                ],
+                    ],
+                  ),
+                ),
               ),
-            ),
+              _buildOverlay(),
+            ],
           );
         },
       );
@@ -355,60 +374,74 @@ extension _PoseDetectionScreenView on _PoseDetectionScreenState {
         }
         final needsRotation = newDeviceRotation == 270;
 
-        Widget previewWidget = Center(
-          child: AspectRatio(
-            aspectRatio: aspectRatio,
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                Builder(
-                  builder: (context) {
-                    try {
-                      final activeController = _mobileInputSource?.controller;
-                      if (activeController == null ||
-                          !activeController.value.isInitialized) {
-                        return const SizedBox.shrink();
-                      }
-                      return mobile_camera.CameraPreview(activeController);
-                    } catch (e) {
-                      return const SizedBox.shrink();
-                    }
-                  },
-                ),
-                if (_currentPose != null)
-                  AspectRatio(
-                    aspectRatio: aspectRatio,
-                    child: CustomPaint(
-                      painter: SkeletonPainter(
-                        pose: _currentPose,
-                        rotationDegrees:
-                            (_sensorOrientation -
-                                (newDeviceRotation == 180
-                                    ? 0
-                                    : newDeviceRotation) +
-                                360) %
-                            360,
-                        imageSize: _cameraImageSize,
-                        inputsAreRotated:
-                            _getMobileImageRotation() !=
-                            InputImageRotation.rotation0deg,
-                        skeletonColor: Colors.greenAccent,
-                        visibleLandmarks: _visibleLandmarks,
-                        visibleBones: _visibleBones,
-                        guide: _currentGuide,
-                      ),
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            Widget cameraContent = FittedBox(
+              fit: BoxFit.cover,
+              clipBehavior: Clip.hardEdge,
+              child: SizedBox(
+                width: constraints.maxWidth,
+                height: constraints.maxWidth / aspectRatio,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    Builder(
+                      builder: (context) {
+                        try {
+                          final activeController =
+                              _mobileInputSource?.controller;
+                          if (activeController == null ||
+                              !activeController.value.isInitialized) {
+                            return const SizedBox.shrink();
+                          }
+                          return mobile_camera.CameraPreview(activeController);
+                        } catch (e) {
+                          return const SizedBox.shrink();
+                        }
+                      },
                     ),
-                  ),
-                _buildOverlay(),
-              ],
-            ),
-          ),
-        );
+                    if (_currentPose != null)
+                      AspectRatio(
+                        aspectRatio: aspectRatio,
+                        child: CustomPaint(
+                          painter: SkeletonPainter(
+                            pose: _currentPose,
+                            rotationDegrees:
+                                (_sensorOrientation -
+                                    (newDeviceRotation == 180
+                                        ? 0
+                                        : newDeviceRotation) +
+                                    360) %
+                                360,
+                            imageSize: _cameraImageSize,
+                            inputsAreRotated:
+                                _getMobileImageRotation() !=
+                                InputImageRotation.rotation0deg,
+                            skeletonColor: Colors.greenAccent,
+                            visibleLandmarks: _visibleLandmarks,
+                            visibleBones: _visibleBones,
+                            guide: _currentGuide,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            );
 
-        if (needsRotation) {
-          return Transform.rotate(angle: 3.14159265359, child: previewWidget);
-        }
-        return previewWidget;
+            if (needsRotation) {
+              cameraContent = Transform.rotate(
+                angle: 3.14159265359,
+                child: cameraContent,
+              );
+            }
+
+            return Stack(
+              fit: StackFit.expand,
+              children: [cameraContent, _buildOverlay()],
+            );
+          },
+        );
       },
     );
   }

--- a/lib/presentation/screens/pose_detection_view.dart
+++ b/lib/presentation/screens/pose_detection_view.dart
@@ -140,11 +140,19 @@ extension _PoseDetectionScreenView on _PoseDetectionScreenState {
             ? _cameraImageSize!.width / _cameraImageSize!.height
             : 16 / 9;
 
+        // Simulator / library replay: portrait + cover over-zooms tall fixture videos.
+        // Contain shows the full frame (letterboxing); landscape stays edge-to-edge.
+        final bool isLandscapeLayout =
+            constraints.maxWidth > constraints.maxHeight;
+        final BoxFit previewFit = isLandscapeLayout
+            ? BoxFit.cover
+            : BoxFit.contain;
+
         return Stack(
           fit: StackFit.expand,
           children: [
             FittedBox(
-              fit: BoxFit.cover,
+              fit: previewFit,
               clipBehavior: Clip.hardEdge,
               child: SizedBox(
                 width: constraints.maxWidth,

--- a/lib/presentation/theme/app_theme.dart
+++ b/lib/presentation/theme/app_theme.dart
@@ -40,8 +40,11 @@ class FitnessPipeTheme extends ThemeExtension<FitnessPipeTheme> {
   });
 
   static const dark = FitnessPipeTheme(
-    overlayBackground: Color(0x801C1C1E),
-    overlayBorder: Color(0x40FFFFFF),
+    // EXPERIMENT: +50% transparency (alphas ×0.5) + stronger blur (38 vs 28).
+    // Revert FitnessPipeTheme.dark to: overlayBackground 0x3E1C1C1E,
+    // overlayBorder 0x24FFFFFF, overlayBlurSigma 28.0.
+    overlayBackground: Color(0x1F1C1C1E),
+    overlayBorder: Color(0x12FFFFFF),
     accentGreen: Color(0xFF30D158),
     poseDetectedColor: Color(0xFF30D158),
     poseNotDetectedColor: Color(0xFFFF453A),
@@ -53,7 +56,9 @@ class FitnessPipeTheme extends ThemeExtension<FitnessPipeTheme> {
     phaseTransition: Color(0xFFFF9F0A),
     phaseComplete: Color(0xFF30D158),
     overlayRadius: 16.0,
-    overlayBlurSigma: 25.0,
+    // EXPERIMENT: stronger frost (was 28) so text stays readable on very light fill.
+    // Revert to 28.0 with the alpha revert above.
+    overlayBlurSigma: 38.0,
     overlayPadding: EdgeInsets.all(16.0),
   );
 
@@ -139,13 +144,15 @@ extension FitnessPipeThemeExtension on BuildContext {
       Theme.of(this).extension<FitnessPipeTheme>() ?? FitnessPipeTheme.dark;
 }
 
-/// Builds a glass-morphism container with blur backdrop.
+/// Builds a glass-morphism container with blur backdrop and a subtle
+/// liquid-glass specular highlight along the top edge.
 class GlassContainer extends StatelessWidget {
   final Widget child;
   final EdgeInsets? padding;
   final double? borderRadius;
   final Color? backgroundColor;
   final Color? borderColor;
+  final bool showSpecular;
 
   const GlassContainer({
     super.key,
@@ -154,32 +161,81 @@ class GlassContainer extends StatelessWidget {
     this.borderRadius,
     this.backgroundColor,
     this.borderColor,
+    this.showSpecular = true,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = context.fpTheme;
     final radius = borderRadius ?? theme.overlayRadius;
+    final borderRadiusGeometry = BorderRadius.circular(radius);
 
     return ClipRRect(
-      borderRadius: BorderRadius.circular(radius),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(
-          sigmaX: theme.overlayBlurSigma,
-          sigmaY: theme.overlayBlurSigma,
-        ),
-        child: Container(
-          padding: padding ?? theme.overlayPadding,
-          decoration: BoxDecoration(
-            color: backgroundColor ?? theme.overlayBackground,
-            borderRadius: BorderRadius.circular(radius),
-            border: Border.all(
-              color: borderColor ?? theme.overlayBorder,
-              width: 0.5,
+      borderRadius: borderRadiusGeometry,
+      child: Stack(
+        clipBehavior: Clip.hardEdge,
+        children: [
+          Positioned.fill(
+            child: BackdropFilter(
+              filter: ImageFilter.blur(
+                sigmaX: theme.overlayBlurSigma,
+                sigmaY: theme.overlayBlurSigma,
+              ),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: backgroundColor ?? theme.overlayBackground,
+                  borderRadius: borderRadiusGeometry,
+                  border: Border.all(
+                    color: borderColor ?? theme.overlayBorder,
+                    width: 0.5,
+                  ),
+                ),
+              ),
             ),
           ),
-          child: child,
-        ),
+          if (showSpecular) ...[
+            Positioned.fill(
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: borderRadiusGeometry,
+                    gradient: LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      // EXPERIMENT: specular ×0.5 — revert to 0.18 / 0.05
+                      colors: [
+                        Colors.white.withValues(alpha: 0.09),
+                        Colors.white.withValues(alpha: 0.025),
+                        Colors.transparent,
+                      ],
+                      stops: const [0.0, 0.22, 0.52],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Positioned.fill(
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: borderRadiusGeometry,
+                    gradient: RadialGradient(
+                      center: const Alignment(-0.82, -0.88),
+                      radius: 1.05,
+                      // EXPERIMENT: specular ×0.5 — revert to 0.10
+                      colors: [
+                        Colors.white.withValues(alpha: 0.05),
+                        Colors.transparent,
+                      ],
+                      stops: const [0.0, 0.48],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+          Padding(padding: padding ?? theme.overlayPadding, child: child),
+        ],
       ),
     );
   }
@@ -200,8 +256,9 @@ ThemeData buildAppTheme() {
     colorScheme: colorScheme,
     useMaterial3: true,
     scaffoldBackgroundColor: Colors.black,
+    // EXPERIMENT: ×0.5 — revert AppBar to 0xA11C1C1E
     appBarTheme: const AppBarTheme(
-      backgroundColor: Color(0xE61C1C1E),
+      backgroundColor: Color(0x511C1C1E),
       foregroundColor: Colors.white,
       elevation: 0,
       centerTitle: true,
@@ -213,17 +270,19 @@ ThemeData buildAppTheme() {
       ),
     ),
     iconTheme: const IconThemeData(color: Colors.white, size: 22),
+    // EXPERIMENT: FAB ×0.5 — revert bg 0x8F1C1C1E, side 0x24FFFFFF
     floatingActionButtonTheme: FloatingActionButtonThemeData(
-      backgroundColor: const Color(0xCC1C1C1E),
+      backgroundColor: const Color(0x481C1C1E),
       foregroundColor: Colors.white,
       elevation: 0,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(22),
-        side: const BorderSide(color: Color(0x33FFFFFF), width: 0.5),
+        side: const BorderSide(color: Color(0x12FFFFFF), width: 0.5),
       ),
     ),
+    // EXPERIMENT: ×0.5 — revert popup 0x7D2C2C2E
     popupMenuTheme: PopupMenuThemeData(
-      color: const Color(0xD92C2C2E),
+      color: const Color(0x3E2C2C2E),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       textStyle: const TextStyle(color: Colors.white, fontSize: 15),
     ),
@@ -233,8 +292,9 @@ ThemeData buildAppTheme() {
       overlayColor: seedColor.withValues(alpha: 0.2),
       inactiveTrackColor: const Color(0xFF3A3A3C),
     ),
+    // EXPERIMENT: ×0.5 — revert dialog 0x982C2C2E
     dialogTheme: DialogThemeData(
-      backgroundColor: const Color(0xF02C2C2E),
+      backgroundColor: const Color(0x4C2C2C2E),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       titleTextStyle: const TextStyle(
         color: Colors.white,
@@ -242,8 +302,9 @@ ThemeData buildAppTheme() {
         fontWeight: FontWeight.w600,
       ),
     ),
+    // EXPERIMENT: ×0.5 — revert sheet 0x982C2C2E
     bottomSheetTheme: const BottomSheetThemeData(
-      backgroundColor: Color(0xF02C2C2E),
+      backgroundColor: Color(0x4C2C2C2E),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(14)),
       ),

--- a/lib/presentation/theme/app_theme.dart
+++ b/lib/presentation/theme/app_theme.dart
@@ -40,8 +40,8 @@ class FitnessPipeTheme extends ThemeExtension<FitnessPipeTheme> {
   });
 
   static const dark = FitnessPipeTheme(
-    overlayBackground: Color(0xCC1C1C1E),
-    overlayBorder: Color(0x33FFFFFF),
+    overlayBackground: Color(0x801C1C1E),
+    overlayBorder: Color(0x40FFFFFF),
     accentGreen: Color(0xFF30D158),
     poseDetectedColor: Color(0xFF30D158),
     poseNotDetectedColor: Color(0xFFFF453A),
@@ -53,7 +53,7 @@ class FitnessPipeTheme extends ThemeExtension<FitnessPipeTheme> {
     phaseTransition: Color(0xFFFF9F0A),
     phaseComplete: Color(0xFF30D158),
     overlayRadius: 16.0,
-    overlayBlurSigma: 20.0,
+    overlayBlurSigma: 25.0,
     overlayPadding: EdgeInsets.all(16.0),
   );
 
@@ -223,7 +223,7 @@ ThemeData buildAppTheme() {
       ),
     ),
     popupMenuTheme: PopupMenuThemeData(
-      color: const Color(0xF02C2C2E),
+      color: const Color(0xD92C2C2E),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       textStyle: const TextStyle(color: Colors.white, fontSize: 15),
     ),

--- a/lib/presentation/widgets/camera_overlay.dart
+++ b/lib/presentation/widgets/camera_overlay.dart
@@ -169,7 +169,8 @@ class CameraOverlay extends StatelessWidget {
                     vertical: 6,
                   ),
                   borderRadius: 8,
-                  backgroundColor: badgeColor?.withValues(alpha: 0.65),
+                  // EXPERIMENT +50% transparency: revert alpha to 0.455
+                  backgroundColor: badgeColor?.withValues(alpha: 0.2275),
                   child: Text(
                     badgeLabel,
                     style: const TextStyle(
@@ -253,7 +254,8 @@ class CameraOverlay extends StatelessWidget {
                               (hasPose
                                       ? theme.poseDetectedColor
                                       : theme.poseNotDetectedColor)
-                                  .withValues(alpha: 0.6),
+                                  // EXPERIMENT: revert to 0.42
+                                  .withValues(alpha: 0.21),
                           blurRadius: 4,
                           spreadRadius: 1,
                         ),
@@ -317,7 +319,8 @@ class CameraOverlay extends StatelessWidget {
       child: GlassContainer(
         padding: const EdgeInsets.all(14),
         borderRadius: 14,
-        borderColor: color.withValues(alpha: 0.5),
+        // EXPERIMENT: revert to 0.35
+        borderColor: color.withValues(alpha: 0.175),
         child: SizedBox(
           width: 140,
           child: Column(

--- a/lib/presentation/widgets/camera_overlay.dart
+++ b/lib/presentation/widgets/camera_overlay.dart
@@ -169,7 +169,7 @@ class CameraOverlay extends StatelessWidget {
                     vertical: 6,
                   ),
                   borderRadius: 8,
-                  backgroundColor: badgeColor?.withValues(alpha: 0.8),
+                  backgroundColor: badgeColor?.withValues(alpha: 0.65),
                   child: Text(
                     badgeLabel,
                     style: const TextStyle(
@@ -317,7 +317,7 @@ class CameraOverlay extends StatelessWidget {
       child: GlassContainer(
         padding: const EdgeInsets.all(14),
         borderRadius: 14,
-        borderColor: color.withValues(alpha: 0.6),
+        borderColor: color.withValues(alpha: 0.5),
         child: SizedBox(
           width: 140,
           child: Column(

--- a/lib/presentation/widgets/camera_overlay.dart
+++ b/lib/presentation/widgets/camera_overlay.dart
@@ -2,9 +2,9 @@ import 'package:fitness_counter/fitness_counter.dart';
 import 'package:flutter/material.dart';
 
 import '../../domain/models/exercise_type.dart';
+import '../../presentation/screens/pose_detection_input_mode.dart';
 import '../theme/app_theme.dart';
 import 'exercise_selector.dart';
-import 'form_feedback_overlay.dart';
 import 'rep_counter_overlay.dart';
 
 /// Shared overlay rendered on top of every camera/file preview mode.
@@ -31,6 +31,10 @@ class CameraOverlay extends StatelessWidget {
   final String poseLabel;
   final String badgeLabel;
   final Color? badgeColor;
+  final bool showInputSelector;
+  final PoseDetectionInputMode? currentInputMode;
+  final List<PoseDetectionInputMode> availableInputModes;
+  final ValueChanged<PoseDetectionInputMode>? onInputModeSelected;
 
   const CameraOverlay({
     super.key,
@@ -52,33 +56,136 @@ class CameraOverlay extends StatelessWidget {
     this.poseLabel = 'Pose',
     this.badgeLabel = '',
     this.badgeColor,
+    this.showInputSelector = false,
+    this.currentInputMode,
+    this.availableInputModes = const [],
+    this.onInputModeSelected,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = context.fpTheme;
+    final safePad = MediaQuery.of(context).padding;
+    final topInset = safePad.top + 8;
+    final bottomInset = safePad.bottom + 8;
+    final leftInset = safePad.left + 16;
+    final rightInset = safePad.right + 16;
 
     return Stack(
       children: [
-        // Top-right: exercise selector + settings gear
+        // Top-center: app title (preserved for test/Maestro compatibility)
         Positioned(
-          top: 16,
-          right: 16,
+          top: topInset,
+          left: leftInset,
+          right: rightInset,
           child: Row(
+            children: [
+              // Input mode switcher (left side)
+              if (showInputSelector && onInputModeSelected != null)
+                PopupMenuButton<PoseDetectionInputMode>(
+                  initialValue: currentInputMode,
+                  icon: const Icon(
+                    Icons.cameraswitch,
+                    color: Colors.white,
+                    size: 22,
+                  ),
+                  tooltip: 'Switch Input',
+                  onSelected: onInputModeSelected,
+                  itemBuilder: (context) => availableInputModes
+                      .map(
+                        (mode) => PopupMenuItem<PoseDetectionInputMode>(
+                          value: mode,
+                          child: Row(
+                            children: [
+                              Icon(
+                                currentInputMode == mode
+                                    ? Icons.radio_button_checked
+                                    : Icons.radio_button_off,
+                                size: 18,
+                              ),
+                              const SizedBox(width: 8),
+                              Text(mode.label),
+                            ],
+                          ),
+                        ),
+                      )
+                      .toList(),
+                ),
+              const Spacer(),
+              const Text(
+                'FitnessPipe',
+                style: TextStyle(
+                  color: Colors.white70,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: -0.4,
+                ),
+              ),
+              const Spacer(),
+              // Pose visibility indicator (right side, mirrors the input switcher)
+              Icon(
+                hasPose ? Icons.visibility : Icons.visibility_off,
+                color: Colors.white54,
+                size: 22,
+              ),
+            ],
+          ),
+        ),
+
+        // Top-right column: exercise selector, badge, then form feedback
+        // Uses a Column so elements flow vertically and never overlap.
+        Positioned(
+          top: topInset + 44,
+          right: rightInset,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
             mainAxisSize: MainAxisSize.min,
             children: [
-              if (selectedExercise != null) ...[
-                _ActionIconButton(
-                  icon: Icons.settings,
-                  onPressed: onShowSettings,
-                  tooltip: 'Settings',
-                ),
-                const SizedBox(width: 8),
-              ],
-              ExerciseSelectorDropdown(
-                selectedExercise: selectedExercise,
-                onChanged: onExerciseSelected,
+              // Exercise selector + settings gear
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (selectedExercise != null) ...[
+                    _ActionIconButton(
+                      icon: Icons.settings,
+                      onPressed: onShowSettings,
+                      tooltip: 'Settings',
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                  ExerciseSelectorDropdown(
+                    selectedExercise: selectedExercise,
+                    onChanged: onExerciseSelected,
+                  ),
+                ],
               ),
+
+              // Mode badge (e.g. SIMULATOR MODE, VIDEO REPLAY)
+              if (badgeLabel.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                GlassContainer(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 6,
+                  ),
+                  borderRadius: 8,
+                  backgroundColor: badgeColor?.withValues(alpha: 0.8),
+                  child: Text(
+                    badgeLabel,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 11,
+                    ),
+                  ),
+                ),
+              ],
+
+              // Form feedback (below selector and badge, never overlapping)
+              if (displayedFeedback != null) ...[
+                const SizedBox(height: 8),
+                _buildFormFeedbackInline(theme),
+              ],
             ],
           ),
         ),
@@ -92,22 +199,15 @@ class CameraOverlay extends StatelessWidget {
             phaseColor: phaseColor,
             currentAngle: currentAngle,
             startPrompt: startPrompt,
-          ),
-
-        // Right side: form feedback
-        if (displayedFeedback != null)
-          FormFeedbackOverlay(
-            feedback: FormFeedback(
-              status: displayedFeedback!.status,
-              issues: [displayedFeedback!.issue],
-            ),
+            topOffset: topInset + 44,
+            leftOffset: leftInset,
           ),
 
         // Bottom-right: action button toolbar
         if (selectedExercise != null)
           Positioned(
-            bottom: 16,
-            right: 16,
+            bottom: bottomInset,
+            right: rightInset,
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -129,8 +229,8 @@ class CameraOverlay extends StatelessWidget {
 
         // Bottom-left: pose detection indicator
         Positioned(
-          bottom: 16,
-          left: 16,
+          bottom: bottomInset,
+          left: leftInset,
           child: Semantics(
             label: hasPose ? 'Pose detected' : 'No pose detected',
             child: GlassContainer(
@@ -172,27 +272,102 @@ class CameraOverlay extends StatelessWidget {
             ),
           ),
         ),
+      ],
+    );
+  }
 
-        // Top-right badge (mode indicator)
-        if (badgeLabel.isNotEmpty)
-          Positioned(
-            top: 64,
-            right: 16,
-            child: GlassContainer(
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-              borderRadius: 8,
-              backgroundColor: badgeColor?.withValues(alpha: 0.8),
-              child: Text(
-                badgeLabel,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 11,
+  Widget _buildFormFeedbackInline(FitnessPipeTheme theme) {
+    final feedback = FormFeedback(
+      status: displayedFeedback!.status,
+      issues: [displayedFeedback!.issue],
+    );
+
+    if (feedback.status == FormStatus.good) {
+      return Semantics(
+        label: 'Good form',
+        child: GlassContainer(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          borderRadius: 20,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.check_circle, color: theme.feedbackGood, size: 18),
+              const SizedBox(width: 6),
+              Text(
+                'Good Form',
+                style: TextStyle(
+                  color: theme.feedbackGood,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
                 ),
               ),
-            ),
+            ],
           ),
-      ],
+        ),
+      );
+    }
+
+    final isBad = feedback.status == FormStatus.bad;
+    final color = isBad ? theme.feedbackBad : theme.feedbackWarning;
+    final icon = isBad ? Icons.cancel : Icons.warning_amber_rounded;
+    final title = isBad ? 'Bad Form' : 'Warning';
+
+    return Semantics(
+      label: '$title: ${feedback.issues.map((i) => i.message).join(', ')}',
+      child: GlassContainer(
+        padding: const EdgeInsets.all(14),
+        borderRadius: 14,
+        borderColor: color.withValues(alpha: 0.6),
+        child: SizedBox(
+          width: 200,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Icon(icon, color: color, size: 22),
+                  const SizedBox(width: 8),
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: color,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 15,
+                    ),
+                  ),
+                ],
+              ),
+              if (feedback.issues.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                ...feedback.issues.map(
+                  (issue) => Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          '\u2022 ',
+                          style: TextStyle(color: Colors.white60),
+                        ),
+                        Expanded(
+                          child: Text(
+                            issue.message,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 13,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/widgets/camera_overlay.dart
+++ b/lib/presentation/widgets/camera_overlay.dart
@@ -319,21 +319,23 @@ class CameraOverlay extends StatelessWidget {
         borderRadius: 14,
         borderColor: color.withValues(alpha: 0.6),
         child: SizedBox(
-          width: 200,
+          width: 140,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
               Row(
                 children: [
-                  Icon(icon, color: color, size: 22),
-                  const SizedBox(width: 8),
-                  Text(
-                    title,
-                    style: TextStyle(
-                      color: color,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 15,
+                  Icon(icon, color: color, size: 20),
+                  const SizedBox(width: 6),
+                  Flexible(
+                    child: Text(
+                      title,
+                      style: TextStyle(
+                        color: color,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/presentation/widgets/exercise_selector.dart
+++ b/lib/presentation/widgets/exercise_selector.dart
@@ -34,7 +34,8 @@ class ExerciseSelectorDropdown extends StatelessWidget {
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(14),
           ),
-          color: const Color(0xF02C2C2E),
+          // EXPERIMENT +50% transparency: revert to 0xA82C2C2E
+          color: const Color(0x542C2C2E),
           itemBuilder: (context) => ExerciseType.values.map((type) {
             final isSelected = type == selectedExercise;
             return PopupMenuItem<ExerciseType>(

--- a/lib/presentation/widgets/form_feedback_overlay.dart
+++ b/lib/presentation/widgets/form_feedback_overlay.dart
@@ -6,8 +6,15 @@ import '../theme/app_theme.dart';
 /// Overlay widget displaying real-time form feedback.
 class FormFeedbackOverlay extends StatelessWidget {
   final FormFeedback feedback;
+  final double topOffset;
+  final double rightOffset;
 
-  const FormFeedbackOverlay({super.key, required this.feedback});
+  const FormFeedbackOverlay({
+    super.key,
+    required this.feedback,
+    this.topOffset = 80,
+    this.rightOffset = 16,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -15,8 +22,8 @@ class FormFeedbackOverlay extends StatelessWidget {
 
     if (feedback.status == FormStatus.good) {
       return Positioned(
-        top: 80,
-        right: 16,
+        top: topOffset,
+        right: rightOffset,
         child: Semantics(
           label: 'Good form',
           child: GlassContainer(
@@ -48,8 +55,8 @@ class FormFeedbackOverlay extends StatelessWidget {
     final title = isBad ? 'Bad Form' : 'Warning';
 
     return Positioned(
-      top: 80,
-      right: 16,
+      top: topOffset,
+      right: rightOffset,
       child: Semantics(
         label: '$title: ${feedback.issues.map((i) => i.message).join(', ')}',
         child: GlassContainer(

--- a/lib/presentation/widgets/form_feedback_overlay.dart
+++ b/lib/presentation/widgets/form_feedback_overlay.dart
@@ -62,7 +62,8 @@ class FormFeedbackOverlay extends StatelessWidget {
         child: GlassContainer(
           padding: const EdgeInsets.all(14),
           borderRadius: 14,
-          borderColor: color.withValues(alpha: 0.6),
+          // EXPERIMENT: revert to 0.42
+          borderColor: color.withValues(alpha: 0.21),
           child: SizedBox(
             width: 200,
             child: Column(

--- a/lib/presentation/widgets/rep_counter_overlay.dart
+++ b/lib/presentation/widgets/rep_counter_overlay.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 
 import '../theme/app_theme.dart';
 
+/// Fixed tile width so the overlay never expands based on start prompt text.
+const double _tileWidth = 155;
+
 /// Overlay widget displaying rep counter information with glass-morphism styling.
 class RepCounterOverlay extends StatelessWidget {
   final int repCount;
@@ -14,6 +17,9 @@ class RepCounterOverlay extends StatelessWidget {
   /// position yet (e.g., "Lower arms to start", "Stand straight to begin").
   final String startPrompt;
 
+  final double topOffset;
+  final double leftOffset;
+
   const RepCounterOverlay({
     super.key,
     required this.repCount,
@@ -22,6 +28,8 @@ class RepCounterOverlay extends StatelessWidget {
     required this.currentAngle,
     this.isActive = false,
     this.startPrompt = '',
+    this.topOffset = 80,
+    this.leftOffset = 16,
   });
 
   @override
@@ -29,105 +37,105 @@ class RepCounterOverlay extends StatelessWidget {
     final theme = context.fpTheme;
 
     return Positioned(
-      top: 80,
-      left: 16,
-      child: GlassContainer(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Guidance prompt (only when inactive)
-            if (!isActive && startPrompt.isNotEmpty) ...[
+      top: topOffset,
+      left: leftOffset,
+      child: SizedBox(
+        width: _tileWidth,
+        child: GlassContainer(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (!isActive && startPrompt.isNotEmpty) ...[
+                Row(
+                  children: [
+                    Icon(
+                      Icons.info_outline,
+                      color: theme.poseNotDetectedColor,
+                      size: 16,
+                    ),
+                    const SizedBox(width: 6),
+                    Flexible(
+                      child: Text(
+                        startPrompt,
+                        style: TextStyle(
+                          color: theme.poseNotDetectedColor,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+              ],
+
               Row(
                 mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  Icon(
-                    Icons.info_outline,
-                    color: theme.poseNotDetectedColor,
-                    size: 16,
+                  Container(
+                    width: 10,
+                    height: 10,
+                    margin: const EdgeInsets.only(right: 8, top: 4),
+                    decoration: BoxDecoration(
+                      color: isActive
+                          ? theme.poseDetectedColor
+                          : theme.poseNotDetectedColor,
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color:
+                              (isActive
+                                      ? theme.poseDetectedColor
+                                      : theme.poseNotDetectedColor)
+                                  .withValues(alpha: 0.6),
+                          blurRadius: 6,
+                          spreadRadius: 1,
+                        ),
+                      ],
+                    ),
                   ),
-                  const SizedBox(width: 6),
-                  Text(
-                    startPrompt,
-                    style: TextStyle(
-                      color: theme.poseNotDetectedColor,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
+                  Semantics(
+                    label: '$repCount',
+                    excludeSemantics: true,
+                    child: Text(
+                      '$repCount',
+                      style: const TextStyle(
+                        fontSize: 48,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                        letterSpacing: -1.0,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Semantics(
+                    label: 'reps',
+                    excludeSemantics: true,
+                    child: const Text(
+                      'reps',
+                      style: TextStyle(
+                        fontSize: 17,
+                        color: Colors.white70,
+                        fontWeight: FontWeight.w500,
+                      ),
                     ),
                   ),
                 ],
               ),
-              const SizedBox(height: 10),
+              const SizedBox(height: 8),
+
+              _buildPhaseChip(),
+
+              const SizedBox(height: 6),
+
+              Text(
+                'Angle: ${currentAngle.toStringAsFixed(1)}°',
+                style: const TextStyle(fontSize: 11, color: Colors.white38),
+              ),
             ],
-
-            // Rep count row
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                // Status indicator
-                Container(
-                  width: 10,
-                  height: 10,
-                  margin: const EdgeInsets.only(right: 8, top: 4),
-                  decoration: BoxDecoration(
-                    color: isActive
-                        ? theme.poseDetectedColor
-                        : theme.poseNotDetectedColor,
-                    shape: BoxShape.circle,
-                    boxShadow: [
-                      BoxShadow(
-                        color:
-                            (isActive
-                                    ? theme.poseDetectedColor
-                                    : theme.poseNotDetectedColor)
-                                .withValues(alpha: 0.6),
-                        blurRadius: 6,
-                        spreadRadius: 1,
-                      ),
-                    ],
-                  ),
-                ),
-                Semantics(
-                  label: '$repCount',
-                  excludeSemantics: true,
-                  child: Text(
-                    '$repCount',
-                    style: const TextStyle(
-                      fontSize: 48,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                      letterSpacing: -1.0,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Semantics(
-                  label: 'reps',
-                  excludeSemantics: true,
-                  child: const Text(
-                    'reps',
-                    style: TextStyle(
-                      fontSize: 17,
-                      color: Colors.white70,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-
-            // Phase chip
-            _buildPhaseChip(),
-
-            const SizedBox(height: 6),
-
-            // Debug angle
-            Text(
-              'Angle: ${currentAngle.toStringAsFixed(1)}°',
-              style: const TextStyle(fontSize: 11, color: Colors.white38),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/widgets/rep_counter_overlay.dart
+++ b/lib/presentation/widgets/rep_counter_overlay.dart
@@ -71,7 +71,6 @@ class RepCounterOverlay extends StatelessWidget {
               ],
 
               Row(
-                mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   Container(
@@ -89,36 +88,48 @@ class RepCounterOverlay extends StatelessWidget {
                               (isActive
                                       ? theme.poseDetectedColor
                                       : theme.poseNotDetectedColor)
-                                  .withValues(alpha: 0.6),
+                                  // EXPERIMENT: revert to 0.42
+                                  .withValues(alpha: 0.21),
                           blurRadius: 6,
                           spreadRadius: 1,
                         ),
                       ],
                     ),
                   ),
-                  Semantics(
-                    label: '$repCount',
-                    excludeSemantics: true,
-                    child: Text(
-                      '$repCount',
-                      style: const TextStyle(
-                        fontSize: 48,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white,
-                        letterSpacing: -1.0,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Semantics(
-                    label: 'reps',
-                    excludeSemantics: true,
-                    child: const Text(
-                      'reps',
-                      style: TextStyle(
-                        fontSize: 17,
-                        color: Colors.white70,
-                        fontWeight: FontWeight.w500,
+                  Expanded(
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      alignment: Alignment.centerLeft,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Semantics(
+                            label: '$repCount',
+                            excludeSemantics: true,
+                            child: Text(
+                              '$repCount',
+                              style: const TextStyle(
+                                fontSize: 48,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white,
+                                letterSpacing: -1.0,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Semantics(
+                            label: 'reps',
+                            excludeSemantics: true,
+                            child: const Text(
+                              'reps',
+                              style: TextStyle(
+                                fontSize: 17,
+                                color: Colors.white70,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ),
@@ -145,7 +156,8 @@ class RepCounterOverlay extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
-        color: phaseColor.withValues(alpha: 0.70),
+        // EXPERIMENT: revert to 0.49
+        color: phaseColor.withValues(alpha: 0.245),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Text(

--- a/lib/presentation/widgets/rep_counter_overlay.dart
+++ b/lib/presentation/widgets/rep_counter_overlay.dart
@@ -145,7 +145,7 @@ class RepCounterOverlay extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
-        color: phaseColor.withValues(alpha: 0.85),
+        color: phaseColor.withValues(alpha: 0.70),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Text(

--- a/packages/fitness_counter/lib/src/exercises/lateral_raise_counter.dart
+++ b/packages/fitness_counter/lib/src/exercises/lateral_raise_counter.dart
@@ -52,7 +52,7 @@ class LateralRaiseCounter implements ExerciseCounter {
   LateralRaiseCounter({
     double? bottomThreshold,
     double? topThreshold,
-    double smoothingAlpha = 0.3,
+    double smoothingAlpha = 0.5,
     int smoothingWarmupFrames = 5,
     Duration? readyHoldTime,
     Duration? minRepDuration,


### PR DESCRIPTION
- Remove AppBar and go fully immersive; absorb input-mode switcher and pose-visibility indicator into the camera overlay with safe-area-aware positioning (MediaQuery.padding)
- Switch camera preview from Center+AspectRatio (letterboxing) to FittedBox(BoxFit.cover) so the feed fills the entire screen edge-to-edge in both portrait and landscape
- Stack exercise selector, mode badge, and form feedback in a Column so form corrections never overlap the dropdown or badge
- Suppress form feedback (visual + voice) while the settings sheet is open
- Gate form analysis on exercise phase: only fire after the waiting phase ends, preventing mixed start-prompt and correction signals
- Extract shared _processFormFeedback() to eliminate triplicated feedback logic across exercise branches
- Fix rep counter tile to a fixed 155pt width with text wrapping so the tile never expands to cover the settings gear
- Improve lateral raise real-camera responsiveness: increase smoothing alpha from 0.3 to 0.5 and lower default top threshold from 70 to 60 degrees to account for 2D projection foreshortening

Made-with: Cursor